### PR TITLE
Fix deprecation warning

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -41,7 +41,7 @@
     "font-family-name-quotes": "always-where-recommended",
     "font-family-no-duplicate-names": true,
     "font-weight-notation": "numeric",
-    "function-blacklist": "rgb",
+    "function-disallowed-list": "rgb",
     "function-calc-no-unspaced-operator": true,
     "function-comma-space-after": "always",
     "function-comma-space-before": "never",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.0.0 (30.10.2020)
+
+* Breaking change: Dropped support of `stylelint` lower than 13.7.0.
+* Added `stylelint` to `peerDependencies`.
+* Updated dependencies.
+
 ## 2.8.1 (27.05.2020)
 
 * Fixed typo in `grid-template-columns` prop name.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@
 
 ## Installation
 
+First, install Stylelint that meets 
+the [peerDependencies requirements](./package.json):
+
+```bash
+npm install --save-dev stylelint
+```
+
+Then install the config:
+
 ```bash
 npm install --save-dev @funboxteam/scss-lint-config
 ```

--- a/README.ru.md
+++ b/README.ru.md
@@ -6,6 +6,15 @@
 
 ## Установка
 
+Сперва необходимо установить версию Stylelint, удовлетворяющую требованиям, 
+описанным в [peerDependencies](./package.json):
+
+```bash
+npm install --save-dev stylelint
+```
+
+Затем можно устанавливать сам конфиг:
+
 ```bash
 npm install --save-dev @funboxteam/scss-lint-config
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funboxteam/scss-lint-config",
-  "version": "2.8.1",
+  "version": "3.0.0",
   "description": "Config for Stylelint SCSS linting",
   "keywords": [
     "stylelint",

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
     "@funboxteam/stylelint-rules": "^1.1.0",
     "stylelint-order": "^0.7.0",
     "stylelint-scss": "^2.1.0"
+  },
+  "peerDependencies": {
+    "stylelint": ">= 13.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
   "license": "MIT",
   "main": "index.js",
   "dependencies": {
-    "@funboxteam/stylelint-rules": "^1.1.0",
-    "stylelint-order": "^0.7.0",
-    "stylelint-scss": "^2.1.0"
+    "@funboxteam/stylelint-rules": "^2.0.0",
+    "stylelint-order": "^4.1.0",
+    "stylelint-scss": "^3.18.0"
   },
   "peerDependencies": {
     "stylelint": ">= 13.7.0"


### PR DESCRIPTION
In [stylelint@13.7.0](https://github.com/stylelint/stylelint/blob/master/CHANGELOG.md#1370) all rules which end with `*-blacklist` have been renamed to `*-dissallow-list`.

So, now this config causes deprecation warning:
```
Deprecation Warning: 'function-blacklist' has been deprecated. Instead use 'function-disallowed-list'. See: https://github.com/stylelint/stylelint/blob/13.7.0/lib/rules/function-blacklist/README.md
```

In this pull request I've fixed that.