### PR TITLE
Bump version to 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 6.0.0 (08.12.2023)
+
+Migration to Stylelint 15
+
+There were no changes on the config itself, but here is the Stylelint
+[migration guide](https://stylelint.io/migration-guide/to-15)
+in case you need it.
+
 ## 5.0.0 (21.06.2023)
 
 Updated dependencies, that led to dropping support for Stylelint 13.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@funboxteam/scss-lint-config",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@funboxteam/scss-lint-config",
-      "version": "5.0.0",
+      "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
         "@funboxteam/stylelint-rules": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funboxteam/scss-lint-config",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Config for Stylelint SCSS linting",
   "keywords": [
     "stylelint",


### PR DESCRIPTION
Bump version for migration to stylelint 15 ([PR](https://github.com/funbox/scss-lint-config/pull/14))